### PR TITLE
Remove unused DngEncoder output thread

### DIFF
--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -120,15 +120,14 @@ Matrix(float m0, float m1, float m2,
 };
 
 DngEncoder::DngEncoder(RawOptions const *options)
-	: Encoder(options), abortEncode_(false), abortOutput_(false), index_(0), frameStop_(0), frames_(0), resetCount_(false), encodeCheck_(false), cache_buffer_(448), compressed(false)
+        : Encoder(options), abortEncode_(false), index_(0), frameStop_(0), frames_(0), resetCount_(false), encodeCheck_(false), cache_buffer_(448), compressed(false)
 {
     options_ = options;
-	// output_thread_ = std::thread(&DngEncoder::outputThread, this);
-	for (int i = 0; i < NUM_ENC_THREADS; i++){
-		encode_thread_[i] = std::thread(std::bind(&DngEncoder::encodeThread, this, i));
-		cache_thread_[i] = std::thread(std::bind(&DngEncoder::cacheThread, this, i));
-	}
-	LOG(2, "Opened DngEncoder");
+        for (int i = 0; i < NUM_ENC_THREADS; i++){
+                encode_thread_[i] = std::thread(std::bind(&DngEncoder::encodeThread, this, i));
+                cache_thread_[i] = std::thread(std::bind(&DngEncoder::cacheThread, this, i));
+        }
+        LOG(2, "Opened DngEncoder");
 }
 
 DngEncoder::~DngEncoder()
@@ -138,9 +137,7 @@ DngEncoder::~DngEncoder()
 		encode_thread_[i].join();
 		cache_thread_[i].join();
 	}
-	abortOutput_ = true;
-	// output_thread_.join();
-	LOG(2, "DngEncoder closed");
+        LOG(2, "DngEncoder closed");
 }
 
 void DngEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -43,14 +43,8 @@ private:
 	void encodeThread(int num);
 
 	void cacheThread(int num);
-	// Handle the output buffers in another thread so as not to block the encoders. The
-	// application can take its time, after which we return this buffer to the encoder for
-	// re-use.
-	void outputThread();
-
-	bool encodeCheck_;
-	bool abortEncode_;
-	bool abortOutput_;
+        bool encodeCheck_;
+        bool abortEncode_;
 	bool resetCount_;
 	uint64_t index_;
 	uint64_t frames_;


### PR DESCRIPTION
## Summary
- clean up `DngEncoder` by removing unused output thread code

## Testing
- `cmake -S . -B build` *(fails: The following required packages were not found: libcamera)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_6847f3a0bed08321a979d6e14632769c