### PR TITLE
Expand README with detailed overview

### DIFF
--- a/DEEP_DIVE.md
+++ b/DEEP_DIVE.md
@@ -1,0 +1,163 @@
+# CinePi RAW Deep Dive
+
+This document supplements the top level `README.md` with more in‑depth information about the code structure and a detailed list of every command line parameter.  It is split into two parts:
+
+1. **Low level overview** – how the major classes work and how data flows through the application.
+2. **High level tutorial** – step by step usage and the full set of command line options.
+
+## Low Level Overview
+
+The `cinepi-raw` executable is built on top of the standard `libcamera` application framework.  The following classes are key:
+
+- **`CinePIRecorder`** (`cinepi/cinepi_recorder.hpp`) derives from `LibcameraApp` and owns a `DngEncoder`.  It exposes callbacks so that encoded data can be written to disk.  Frames are queued and returned once the encoder signals completion.
+- **`CinePIController`** (`cinepi/cinepi_controller.hpp`) runs in a background thread.  It connects to Redis and watches keys like `is_recording`, `iso` and `shutter_s`.  When values change it updates camera controls and publishes statistics.
+- **`DngEncoder`** (`cinepi/dng_encoder.*`) receives raw frame buffers and writes CinemaDNG files.  The encoder also publishes metadata when requested.
+- **`cinepi_raw.cpp`** contains the main event loop.  Frames are captured, handed to the encoder and optionally displayed via the preview subsystem.  The loop reacts to Redis messages so recording can be started and stopped without restarting the application.
+
+During initialisation the controller synchronises defaults such as width, height and ISO with Redis.  New clip folders are created under the path stored in `mediaDest` using helper functions from `cinepi/utils.hpp`.
+
+### Redis Keys
+
+Constants for the control keys are defined in `cinepi_state.hpp`.  Examples include `CONTROL_KEY_RECORD`, `CONTROL_KEY_ISO` and `CONTROL_KEY_SHUTTER_SPEED`.
+When a value is changed the key name is published on the `cp_controls` channel which causes the controller to reconfigure the camera.
+
+## High Level Tutorial
+
+1. **Build dependencies** such as `libcamera`, `redis++` and `hiredis`.  The normal build uses CMake:
+   ```bash
+   sudo apt install build-essential cmake libtiff-dev libhiredis-dev libredis++-dev
+   git clone https://github.com/cinepi/cinepi-raw.git
+   cd cinepi-raw && mkdir build && cd build
+   cmake ..
+   make -j4
+   ```
+2. **Run Redis** so that `cinepi-raw` can exchange control messages.
+3. **Launch the application**.  A basic invocation looks like
+   ```bash
+   ./build/cinepi-raw --redis redis://127.0.0.1:6379/0 --width 1920 --height 1080
+   ```
+4. **Toggle recording** using the Redis keys.  For example
+   ```bash
+   redis-cli set is_recording 1
+   redis-cli publish cp_controls is_recording
+   ```
+   Setting `0` stops recording.
+5. **Inspect output** in the folder configured by `--mediaDest` (defaults to `/media/RAW`).
+
+### Complete Argument Reference
+
+The program inherits a large set of options from several classes.  They are grouped below roughly in the order they appear in `core/options.hpp`, `core/video_options.hpp`, `core/still_options.hpp` and `cinepi/raw_options.hpp`.
+
+#### Generic Options
+- `--help` (`-h`)
+- `--version`
+- `--list-cameras`
+- `--camera <index>`
+- `--verbose` (`-v`)
+- `--config` (`-c`) path
+- `--info-text <string>`
+- `--width <pixels>`
+- `--height <pixels>`
+- `--timeout` (`-t` ms)
+- `--output` (`-o` file)
+- `--post-process-file <json>`
+- `--rawfull`
+- `--nopreview` (`-n`)
+- `--preview` (`-p` x,y,w,h)
+- `--fullscreen` (`-f`)
+- `--qt-preview`
+- `--hflip`
+- `--vflip`
+- `--rotation <0|180>`
+- `--roi x,y,w,h`
+- `--shutter <us>`
+- `--analoggain <gain>`
+- `--gain <gain>`
+- `--metering <mode>`
+- `--exposure <mode>`
+- `--ev <comp>`
+- `--awb <mode>`
+- `--awbgains r,b`
+- `--flush`
+- `--wrap <count>`
+- `--brightness <val>`
+- `--contrast <val>`
+- `--saturation <val>`
+- `--sharpness <val>`
+- `--framerate <fps>`
+- `--denoise <mode>`
+- `--viewfinder-width <px>`
+- `--viewfinder-height <px>`
+- `--tuning-file <file>`
+- `--lores-width <px>`
+- `--lores-height <px>`
+- `--mode W:H:bit-depth:P|U`
+- `--viewfinder-mode W:H:bit-depth:P|U`
+- `--buffer-count <n>`
+- `--viewfinder-buffer-count <n>`
+- `--autofocus-mode <mode>`
+- `--autofocus-range <mode>`
+- `--autofocus-speed <mode>`
+- `--autofocus-window x,y,w,h`
+- `--lens-position <val>`
+- `--hdr`
+- `--metadata <file>`
+- `--metadata-format txt|json`
+
+#### Video Options
+- `--bitrate` (`-b`)
+- `--profile`
+- `--level`
+- `--intra` (`-g`)
+- `--inline`
+- `--codec h264|mjpeg|yuv420`
+- `--save-pts <file>`
+- `--quality` (`-q`, MJPEG)
+- `--listen` (`-l`)
+- `--keypress` (`-k`)
+- `--signal` (`-s`)
+- `--initial pause|record`
+- `--split`
+- `--segment <ms>`
+- `--circular <MB>`
+- `--frames <count>`
+- `--libav-format <fmt>` (if built with libav)
+- `--libav-audio` (if built with libav)
+- `--audio-codec <codec>`
+- `--audio-source <src>`
+- `--audio-device <dev>`
+- `--audio-bitrate <bps>`
+- `--audio-samplerate <Hz>`
+- `--av-sync <us>`
+
+#### Still Options
+- `--quality` (`-q`, JPEG)
+- `--exif` (`-x` key=value)
+- `--timelapse <ms>`
+- `--framestart <n>`
+- `--datetime`
+- `--timestamp`
+- `--restart <interval>`
+- `--keypress` (`-k`)
+- `--signal` (`-s`)
+- `--thumb width:height:quality|none`
+- `--encoding` (`-e` jpg|png|rgb|bmp|yuv420)
+- `--raw` (`-r`)
+- `--latest <name>`
+- `--immediate`
+- `--autofocus-on-capture`
+
+#### cinepi-raw Specific Options
+- `--redis <url>`
+- `--clip_number <n>`
+- `--mediaDest <path>`
+- `--folder <name>`
+- `--wb <multiplier>`
+- `--sensor <string>`
+- `--model <string>`
+- `--make <string>`
+- `--serial <string>`
+- `--clipping <percent>`
+
+Running `./cinepi-raw --help` will print these options with the same descriptions that appear in the source.
+

--- a/README.md
+++ b/README.md
@@ -1,23 +1,235 @@
+# CinePi RAW
+
 ![cp_raw_banner](https://github.com/cinepi/cinepi-raw/assets/25234407/71591abc-f9b2-467e-806f-30557bcd1491)
 
-*fork of rpicam-apps that builds upon the rpicam-raw app, offering cinema dng recording capabillities and integration with REDIS offering an abstract "API" like layer for custom integrations / controls.*
+*CinePi RAW* is a fork of Raspberry Pi's `rpicam-apps` project that extends the original `libcamera-raw` application with CinemaDNG recording support and a Redis driven control interface. This repository also keeps the original demo applications from `rpicam-apps` and provides a set of utilities and post-processing examples for experimentation.
 
-Requirements
------
-Please install the below requirements before continuing with the rest of the build process:
+## Table of Contents
 
-[Redis](https://github.com/redis/redis)
+1. [Features](#features)
+2. [Requirements](#requirements)
+3. [Building-from-Source](#building-from-source)
+4. [Directory-Layout](#directory-layout)
+5. [Applications-and-Scripts](#applications-and-scripts)
+6. [Command-Line-Options](#command-line-options)
+7. [Using-the-Redis-Interface](#using-the-redis-interface)
+8. [Example-Workflow](#example-workflow)
+9. [Tutorial](#tutorial)
+10. [License](#license)
 
-[Hiredis](https://github.com/redis/hiredis)
+## Features
 
-[Redis++](https://github.com/sewenew/redis-plus-plus)
+- Capture RAW frames directly to CinemaDNG sequences.
+- Redis based API for controlling recording parameters remotely.
+- Includes standard `libcamera-hello`, `libcamera-still`, `libcamera-jpeg`, `libcamera-vid`, `libcamera-raw` and `libcamera-detect` applications.
+- Optional post-processing stages (object detection, HDR, segmentation, etc.) configured via JSON files in `assets/`.
 
-Build
------
-For usage and build instructions, see the official Raspberry Pi documenation pages [here.](https://www.raspberrypi.com/documentation/computers/camera_software.html#building-libcamera-and-libcamera-apps)
+## Architecture Overview
 
-License
--------
+CinePi RAW keeps the original libcamera application framework and layers a small controller on top. The `cinepi-raw` executable interacts with the camera through `LibcameraApp` classes in `core/`. Frames are passed to `DngEncoder` which writes CinemaDNG files while `CinePIController` publishes and receives settings from Redis. This design allows you to tweak camera parameters in real time without restarting the app.
+## Requirements
+Install the following dependencies before building:
 
-The source code is made available under the simplified [BSD 2-Clause license](https://spdx.org/licenses/BSD-2-Clause.html).
+- [Redis](https://github.com/redis/redis)
+- [Hiredis](https://github.com/redis/hiredis)
+- [Redis++](https://github.com/sewenew/redis-plus-plus)
+- libtiff development files
+- libcamera and its headers (see Raspberry Pi documentation)
 
+## Building from Source
+
+
+The project uses CMake. The general workflow on a Raspberry Pi is:
+
+```bash
+sudo apt install build-essential cmake libtiff-dev libhiredis-dev libredis++-dev
+# build libcamera separately if not already installed
+# see: https://www.raspberrypi.com/documentation/computers/camera_software.html#building-libcamera-and-libcamera-apps
+
+# fetch the code
+git clone https://github.com/cinepi/cinepi-raw.git
+cd cinepi-raw
+mkdir build && cd build
+cmake ..
+make -j4
+# sudo make install  # optional
+```
+
+The resulting binaries appear in `build/`. To cross compile on a Linux host use a toolchain file and set the installation prefix:
+
+```bash
+cmake .. -DCMAKE_TOOLCHAIN_FILE=/path/to/toolchain.cmake -DCMAKE_INSTALL_PREFIX=/opt/cinepi
+make
+```
+
+
+## Directory Layout
+
+The repository closely mirrors the upstream `libcamera-apps` layout with additional source files for the CinePi RAW functionality.
+
+- **apps/** – Standard demo applications from `rpicam-apps` (`libcamera-hello`, `libcamera-jpeg`, `libcamera-still`, `libcamera-vid`, `libcamera-raw`, `libcamera-detect`). These serve as examples and test programs.
+- **cinepi/** – Implementation of `cinepi-raw` together with the `CinePIController` that talks to Redis. Also contains the DNG encoder and small helper utilities.
+- **core/** – Common `libcamera` helper code (`LibcameraApp`, option parsers and the post-processing pipeline) shared by all apps.
+- **encoder/** – H.264/MJPEG encoders plus the custom DNG encoder used by CinePi RAW.
+- **image/** – Routines for handling BMP, JPEG, PNG and DNG images.
+- **output/** – Base classes that write encoded output to files or pipes. Applications plug their encoder into these objects.
+- **preview/** – Abstraction layer for displaying the camera preview with DRM/KMS, EGL, Qt or a null implementation for headless operation.
+- **post_processing_stages/** – Example post-processing stages (HDR merge, object detection, segmentation, etc.). They are dynamically loaded based on JSON configuration.
+- **assets/** – Sample JSON files demonstrating how to configure post-processing stages.
+- **utils/** – Python helper scripts (`camera-bug-report`, `checkstyle.py`, `timestamp.py`, `test.py`, `version.py`).
+
+### Key Components
+
+- **cinepi/cinepi_raw.cpp** – main entry point running the event loop and coordinating Redis control.
+- **cinepi/cinepi_controller.* **– background thread handling Redis messages and publishing camera statistics.
+- **cinepi/dng_encoder.* **– writes frames in CinemaDNG format with optional lossless compression.
+- **core/libcamera_app.* **– base class wrapping libcamera APIs and providing the preview and capture pipeline.
+- **encoder/** – contains concrete encoder implementations, including H.264 and MJPEG, reused by the demos.
+- **utils/test.py** – runs basic automated tests to verify the binaries operate correctly.
+
+## Applications and Scripts
+
+### cinepi-raw
+
+Main application that records CinemaDNG frames. It uses `CinePIController` to read and publish state via Redis and relies on the custom DNG encoder in the `encoder/` directory. The program exposes all standard libcamera options plus a few extras:
+
+- `--redis` – Redis connection string (default `redis://127.0.0.1:6379/0`).
+- `--clip_number` – Starting clip counter.
+- `--mediaDest` – Path where clips are created (default `/media/RAW`).
+- `--wb` – Fixed white balance multiplier.
+- `--clipping` – Highlight clipping threshold.
+
+Run `./cinepi-raw --help` to see the full list of options inherited from `VideoOptions` and `Options`.
+
+### libcamera-* utilities
+
+The `apps/` directory contains the standard utilities from `rpicam-apps`:
+
+- **libcamera-hello** – Simple preview window.
+- **libcamera-jpeg** – Capture a JPEG image.
+- **libcamera-still** – Flexible still image capture tool.
+- **libcamera-vid** – Record video (H.264, MJPEG or raw YUV).
+- **libcamera-raw** – Record raw frames without encoding.
+- **libcamera-detect** – Example using post-processing with TensorFlow Lite.
+
+All programs share the same extensive command line options (see below).
+
+### Utility scripts
+
+- **camera-bug-report** – Collect system information and logs for bug reports.
+- **checkstyle.py** – clang-format based style checker used by CI (`./utils/checkstyle.py --fix` formats the codebase).
+- **timestamp.py** – Analyse timestamp files created with the `--save-pts` option.
+- **test.py** – Basic smoke tests for the applications (requires the binaries to be built beforehand).
+- **version.py** – Helper for generating version strings from git.
+
+## Command Line Options
+
+All applications inherit a large set of command line options defined in `core/options.hpp` and `core/video_options.hpp`. Highlights include:
+
+- General: `--camera`, `--width`, `--height`, `--nopreview`, `--fullscreen`, `--timeout`, `--output`.
+- Image controls: `--shutter`, `--gain`, `--awb`, `--awbgains`, `--brightness`, `--contrast`, `--saturation`, `--sharpness`.
+- Video settings: `--codec` (`h264`, `mjpeg`, `yuv420`), `--bitrate`, `--profile`, `--level`, `--intra`, `--listen`, `--split`, `--segment`, `--circular`.
+- Focus and exposure: `--metering`, `--exposure`, `--ev`, `--autofocus-mode`, `--lens-position`.
+- Misc: `--save-pts`, `--viewfinder-width`, `--viewfinder-height`, `--lores-width`, `--lores-height`, `--denoise`, `--hdr`, `--metadata`.
+### cinepi-raw specific options
+
+In addition to the generic video options the program defines extra parameters:
+
+- `--redis` – connection string for the Redis server.
+- `--clip_number` – initial clip counter value.
+- `--mediaDest` – directory where clip folders are created.
+- `--folder` – override the folder name for the next recording.
+- `--wb` – fixed white balance multiplier (disables auto white balance).
+- `--sensor` – override the sensor model string written to DNG metadata.
+- `--model` – camera model field for metadata.
+- `--make` – camera make field for metadata.
+- `--serial` – serial number for metadata.
+- `--clipping` – clipping percentage to mark highlight saturation.
+
+`cinepi-raw` adds Redis specific parameters noted above.
+
+## Redis Keys and Controls
+
+The application reads and writes several keys under Redis. The most important ones are listed below:
+
+| Key | Purpose |
+|-----|---------|
+| `is_recording` | Set to `1` or `0` to start/stop recording. |
+| `iso` | Analogue gain value in ISO/100 units. |
+| `awb` | Enable (`1`) or disable (`0`) automatic white balance. |
+| `cg_rb` | Comma separated red and blue gains when AWB is disabled. |
+| `shutter_a` | Shutter angle in degrees. |
+| `shutter_s` | Shutter speed in frames per second. |
+| `fps` | Desired capture framerate. |
+| `width` | Output width. |
+| `height` | Output height. |
+| `mode` | Camera sensor mode string. |
+| `compress` | Enable DNG compression (`1` or `0`). |
+| `cam_init` | Flag to reconfigure the camera. |
+| `rec` | Publish to trigger start/stop recording. |
+| `stll` | Publish to capture a single still frame. |
+## Using the Redis Interface
+
+`cinepi-raw` listens to the `cp_controls` channel. To change a parameter:
+
+1. Set the desired value in Redis.
+2. Publish the key name on the `cp_controls` channel.
+
+Values are read as strings and interpreted by the application. The recorder publishes statistics on the `cp_stats` channel and histograms on `cp_histogram` so you can build custom monitoring dashboards.
+
+Example: start recording a new clip
+
+```bash
+redis-cli set is_recording 1
+redis-cli publish cp_controls is_recording
+```
+
+To stop recording send `0` instead. Keys for other settings include `iso`, `awb`, `cg_rb`, `shutter_s`, `fps`, `width`, `height` and `compress`. The controller publishes statistics on the `cp_stats` channel and histograms on `cp_histogram`.
+
+A minimal Python snippet to toggle recording might look like:
+
+```python
+import redis
+r = redis.Redis()
+r.set("is_recording", 1)
+r.publish("cp_controls", "is_recording")
+```
+
+## Example Workflow
+
+```bash
+# Start the redis server (if not already running)
+redis-server &
+
+# Run the application
+./build/cinepi-raw --redis redis://127.0.0.1:6379/0 --width 1920 --height 1080
+
+# Trigger a recording
+redis-cli set is_recording 1
+redis-cli publish cp_controls is_recording
+
+# Stop
+redis-cli set is_recording 0
+redis-cli publish cp_controls is_recording
+```
+
+Captured DNG frames are stored under `/media/RAW/<generated_folder>`.
+
+## Tutorial
+
+1. **Build and install dependencies** using the instructions above. Compile the project with `cmake` and `make`.
+2. **Launch `redis-server`** so that the controller can communicate.
+3. **Run `cinepi-raw`**. The program prints log messages describing the current configuration.
+4. **Use `redis-cli` or any Redis client** to change camera parameters at runtime. Modify exposure, gain or toggle recording without restarting the app.
+5. **Inspect the output**. Recorded frames appear as DNG files in clip folders. Metadata and histogram information is published on Redis channels for monitoring or custom UI integration.
+6. **Experiment with post-processing** by providing one of the JSON files in `assets/` using the `--post-process-file` option. These configure stages such as HDR merging or TensorFlow Lite inference.
+7. **Automate control** by writing small Redis clients (see Python snippet above) or integrating the keys into your own UI.
+
+8. **Capture single frames** by publishing `stll` on the control channel to trigger a still capture.
+9. **Set metadata strings** using `--make`, `--model` and `--serial` to embed camera information in each DNG file.
+10. **Monitor camera state** by subscribing to `cp_stats` and `cp_histogram` for framerate and histogram data.
+For more advanced documentation about libcamera and its options see the official Raspberry Pi camera docs.
+
+## License
+
+The source code is made available under the simplified [BSD 2‑Clause license](https://spdx.org/licenses/BSD-2-Clause.html).


### PR DESCRIPTION
## Summary
- document CinePi RAW architecture
- provide step-by-step build and cross-compile instructions
- restore directory breakdown and list key components
- list cinepi-raw options and redis keys
- extend tutorial with extra usage tips

## Testing
- `python3 utils/test.py -a hello` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848647608988321943f75f0c6fa554d