### PR TITLE
Avoid repeated thumbnail allocations

### DIFF
--- a/cinepi/dng_encoder.cpp
+++ b/cinepi/dng_encoder.cpp
@@ -300,20 +300,23 @@ void DngEncoder::dng_save(uint8_t const *mem, StreamInfo const &info, uint8_t co
 
 		// LOG(1, losize << " , " << loinfo.width << " , " << loinfo.height << " , " << loinfo.stride);
 
-		size_t rowSize = loinfo.stride*3;
-		size_t thumbSize = rowSize*loinfo.height;
-		uint8_t *thumb = (uint8_t*)malloc(thumbSize);
-		uint8_t *read = &thumb[0];
-		if(nv21_to_rgb(thumb, lomem, loinfo.stride, loinfo.height) != 1){
-			throw std::runtime_error("error converting yuv2rgb image data");
-		}
-		for(int y = 0; y < loinfo.height; y++){
-			if (TIFFWriteScanline(tif, (read + y*rowSize), y, 0) != 1)
-				throw std::runtime_error("error writing DNG image data");
-			
-		}
-		free(thumb);
-		TIFFWriteDirectory(tif);
+                size_t rowSize = loinfo.stride * 3;
+                size_t thumbSize = rowSize * loinfo.height;
+
+                if (thumb_buffer_.size() < thumbSize)
+                        thumb_buffer_.resize(thumbSize);
+
+                uint8_t *thumb = thumb_buffer_.data();
+                uint8_t *read = thumb;
+
+                if (nv21_to_rgb(thumb, lomem, loinfo.stride, loinfo.height) != 1)
+                        throw std::runtime_error("error converting yuv2rgb image data");
+                for(int y = 0; y < loinfo.height; y++){
+                        if (TIFFWriteScanline(tif, (read + y*rowSize), y, 0) != 1)
+                                throw std::runtime_error("error writing DNG image data");
+
+                }
+                TIFFWriteDirectory(tif);
 
 		// LOG(1, "w: " << info.width << ", " << info.height);
 

--- a/cinepi/dng_encoder.hpp
+++ b/cinepi/dng_encoder.hpp
@@ -107,4 +107,7 @@ private:
         std::vector<size_t> lo_pool_size_;
         std::queue<int> free_pool_indices_;
         std::mutex pool_mutex_;
+
+        // Buffer for the thumbnail image, resized as required
+        std::vector<uint8_t> thumb_buffer_;
 };


### PR DESCRIPTION
## Summary
- keep a persistent buffer for thumbnails in `DngEncoder`
- reuse this buffer for saving the thumbnail image

## Testing
- `cmake ..` *(fails: HIREDIS_HEADER not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a73e9fe648321a3edcb413222c101